### PR TITLE
[FLIR] Fix crash on static negative stride in reinterpret_cast stride lookup

### DIFF
--- a/lib/UtilsIncubated/Utils.cpp
+++ b/lib/UtilsIncubated/Utils.cpp
@@ -94,7 +94,8 @@ getLastStrideOfReinterpretCastOp(memref::ReinterpretCastOp op) {
 
   if (op.getStaticStrides().back() > 0) {
     return op.getStaticStrides().back();
-  } else if (isa<BlockArgument>(op.getStrides().back())) {
+  } else if (!op.getStrides().empty() &&
+             isa<BlockArgument>(op.getStrides().back())) {
     auto u = op.getStrides().back();
     while (auto blkArg = dyn_cast<BlockArgument>(u)) {
       if (auto forOp = dyn_cast<scf::ForOp>(blkArg.getOwner()->getParentOp())) {


### PR DESCRIPTION
  `getLastStrideOfReinterpretCastOp` crashes when the last-dim stride folds
  to a static negative value (e.g. from a flip / reversed access pattern).

  In that case `getStaticStrides().back() > 0` is false, so it falls into the
  `else if` branch and calls `op.getStrides().back()` — but `getStrides()`
  only holds the *dynamic* strides and is empty here, so `.back()` reads out
  of bounds and crashes.

  Fix: guard the branch with an empty-check before indexing the dynamic
  strides list. When the last stride is a static negative constant, the
  existing tail logic already resolves it correctly via the mixed-stride
  Attribute path.

  Reproduced with a `torch.flip` kernel (FlagGems test_flip) that previously
  core-dumped in `--triton-to-linalg-incubated`; passes after the fix